### PR TITLE
manager: fix plugin healthcheck logic

### DIFF
--- a/plugins/manager/manager.go
+++ b/plugins/manager/manager.go
@@ -201,7 +201,7 @@ func (pm *PluginManager) Dispense(name, pluginType string) (PluginInstance, erro
 	inst, exists := pm.pluginInstances[pID]
 
 	if exists {
-		if _, err := pm.pluginInfo(pID, inst); err != nil {
+		if _, err := pm.pluginInfo(pID, inst.Plugin()); err != nil {
 			// The plugin exists, but is broken. Remove it.
 			pm.logger.Warn("plugin failed healthcheck", "plugin_name", pID.Name, "error", err)
 			pm.killPluginLocked(pID)

--- a/plugins/manager/manager.go
+++ b/plugins/manager/manager.go
@@ -201,15 +201,15 @@ func (pm *PluginManager) Dispense(name, pluginType string) (PluginInstance, erro
 	inst, exists := pm.pluginInstances[pID]
 
 	if exists {
-		if _, err := pm.pluginInfo(pID, inst); err == nil {
+		if _, err := pm.pluginInfo(pID, inst); err != nil {
+			// The plugin exists, but is broken. Remove it.
+			pm.logger.Warn("plugin failed healthcheck", "plugin_name", pID.Name, "error", err)
+			pm.killPluginLocked(pID)
+		} else {
 			// Plugin is fine, return it
 			pm.pluginInstancesLock.Unlock()
 			return inst, nil
 		}
-
-		// The plugin exists, but is broken. Remove it.
-		pm.logger.Warn("plugin failed healthcheck", "plugin_name", pID.Name)
-		pm.killPluginLocked(pID)
 	} else {
 		pm.logger.Warn("plugin not in store", "plugin_name", pID.Name)
 	}


### PR DESCRIPTION
Follow-up to https://github.com/kentik/nomad-autoscaler/pull/2

* Improve the logging situation when a plugin healthcheck fails
* Actually make the plugin healthcheck work :grimacing: