### PR TITLE
Autoscaler fixes for disconnected nodes

### DIFF
--- a/mocks/pkg/node/node.go
+++ b/mocks/pkg/node/node.go
@@ -5,6 +5,7 @@
 //
 //	mockgen -destination=../../mocks/pkg/node/node.go . Status
 //
+
 // Package mock_node is a generated GoMock package.
 package mock_node
 
@@ -18,6 +19,7 @@ import (
 type MockStatus struct {
 	ctrl     *gomock.Controller
 	recorder *MockStatusMockRecorder
+	isgomock struct{}
 }
 
 // MockStatusMockRecorder is the mock recorder for MockStatus.
@@ -38,15 +40,44 @@ func (m *MockStatus) EXPECT() *MockStatusMockRecorder {
 }
 
 // IsIneligible mocks base method.
-func (m *MockStatus) IsIneligible(arg0 string) bool {
+func (m *MockStatus) IsIneligible(nodeID string) bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsIneligible", arg0)
+	ret := m.ctrl.Call(m, "IsIneligible", nodeID)
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
 // IsIneligible indicates an expected call of IsIneligible.
-func (mr *MockStatusMockRecorder) IsIneligible(arg0 any) *gomock.Call {
+func (mr *MockStatusMockRecorder) IsIneligible(nodeID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIneligible", reflect.TypeOf((*MockStatus)(nil).IsIneligible), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsIneligible", reflect.TypeOf((*MockStatus)(nil).IsIneligible), nodeID)
+}
+
+// IsUnavailable mocks base method.
+func (m *MockStatus) IsUnavailable(nodeID string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsUnavailable", nodeID)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsUnavailable indicates an expected call of IsUnavailable.
+func (mr *MockStatusMockRecorder) IsUnavailable(nodeID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsUnavailable", reflect.TypeOf((*MockStatus)(nil).IsUnavailable), nodeID)
+}
+
+// Stats mocks base method.
+func (m *MockStatus) Stats() (int, int) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Stats")
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(int)
+	return ret0, ret1
+}
+
+// Stats indicates an expected call of Stats.
+func (mr *MockStatusMockRecorder) Stats() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stats", reflect.TypeOf((*MockStatus)(nil).Stats))
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -14,6 +14,8 @@ import (
 
 type Status interface {
 	IsIneligible(nodeID string) bool
+	IsUnavailable(nodeID string) bool
+	Stats() (total int, unavailable int)
 }
 
 type NodeStatusWatcher struct {
@@ -32,7 +34,13 @@ type NodeStatusWatcher struct {
 	lastUpdated int64
 
 	ineligibleNodes map[string]struct{}
-	mw              sync.RWMutex // protects ineligibleNodes and isRunning
+
+	// unavailableNodes holds nodes that cannot host allocations, whether the
+	// client is down or only partitioned away from the servers.
+	unavailableNodes map[string]struct{}
+	totalNodes       int
+
+	mw sync.RWMutex // protects the node maps, totalNodes and isRunning
 }
 
 var (
@@ -126,6 +134,21 @@ func (n *NodeStatusWatcher) IsIneligible(nodeID string) bool {
 	return exists
 }
 
+func (n *NodeStatusWatcher) IsUnavailable(nodeID string) bool {
+	n.mw.RLock()
+	defer n.mw.RUnlock()
+
+	_, exists := n.unavailableNodes[nodeID]
+	return exists
+}
+
+func (n *NodeStatusWatcher) Stats() (int, int) {
+	n.mw.RLock()
+	defer n.mw.RUnlock()
+
+	return n.totalNodes, len(n.unavailableNodes)
+}
+
 func (n *NodeStatusWatcher) SetClient(client *api.Client) {
 	n.mw.Lock()
 	defer n.mw.Unlock()
@@ -150,12 +173,23 @@ func (n *NodeStatusWatcher) updateState(nodes []*api.NodeListStub, err error) {
 	}
 
 	before := len(n.ineligibleNodes)
+	beforeUnavailable := len(n.unavailableNodes)
+
 	n.ineligibleNodes = filterIneligibleNodes(nodes)
+	n.unavailableNodes = filterUnavailableNodes(nodes)
+	n.totalNodes = len(nodes)
 	n.lastUpdated = time.Now().UTC().UnixNano()
+
 	after := len(n.ineligibleNodes)
+	afterUnavailable := len(n.unavailableNodes)
 
 	if before != after {
 		n.logger.Info("updating ineligible status", "ineligible", after)
+	}
+
+	if beforeUnavailable != afterUnavailable {
+		n.logger.Info("updating unavailable status",
+			"unavailable", afterUnavailable, "total", n.totalNodes)
 	}
 }
 
@@ -165,6 +199,8 @@ func (n *NodeStatusWatcher) setStopState() {
 
 	n.isRunning = false
 	n.ineligibleNodes = nil
+	n.unavailableNodes = nil
+	n.totalNodes = 0
 	n.lastUpdated = time.Now().UTC().UnixNano()
 }
 
@@ -182,4 +218,20 @@ func filterIneligibleNodes(nodes []*api.NodeListStub) map[string]struct{} {
 	}
 
 	return ineligible
+}
+
+// filterUnavailableNodes returns nodes that cannot host allocations. A
+// partitioned client reports "disconnected" and only becomes "down" once its
+// disconnect.lost_after window expires, so both must be treated as lost
+// capacity to avoid a cliff-edge count drop at expiry.
+func filterUnavailableNodes(nodes []*api.NodeListStub) map[string]struct{} {
+	unavailable := make(map[string]struct{})
+
+	for _, node := range nodes {
+		if node.Status == api.NodeStatusDown || node.Status == api.NodeStatusDisconnected {
+			unavailable[node.ID] = struct{}{}
+		}
+	}
+
+	return unavailable
 }

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -1,0 +1,97 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_filterUnavailableNodes(t *testing.T) {
+	testCases := []struct {
+		name     string
+		nodes    []*api.NodeListStub
+		expected []string
+	}{
+		{
+			name:     "no nodes",
+			nodes:    nil,
+			expected: []string{},
+		},
+		{
+			name: "down and disconnected are both unavailable",
+			nodes: []*api.NodeListStub{
+				{ID: "ready", Status: api.NodeStatusReady},
+				{ID: "down", Status: api.NodeStatusDown},
+				{ID: "disconnected", Status: api.NodeStatusDisconnected},
+				{ID: "initializing", Status: api.NodeStatusInit},
+			},
+			expected: []string{"down", "disconnected"},
+		},
+		{
+			name: "scheduling eligibility does not affect availability",
+			nodes: []*api.NodeListStub{
+				{ID: "drained", Status: api.NodeStatusReady, SchedulingEligibility: nodeStatusIneligible},
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := filterUnavailableNodes(tc.nodes)
+
+			assert.Len(t, got, len(tc.expected))
+			for _, id := range tc.expected {
+				assert.Contains(t, got, id)
+			}
+		})
+	}
+}
+
+func Test_filterIneligibleNodes(t *testing.T) {
+	nodes := []*api.NodeListStub{
+		{ID: "eligible", SchedulingEligibility: "eligible"},
+		{ID: "ineligible", SchedulingEligibility: nodeStatusIneligible},
+		// A partitioned node stays eligible, which is why disconnects need
+		// tracking separately from drains.
+		{ID: "disconnected", Status: api.NodeStatusDisconnected, SchedulingEligibility: "eligible"},
+	}
+
+	got := filterIneligibleNodes(nodes)
+
+	assert.Len(t, got, 1)
+	assert.Contains(t, got, "ineligible")
+}
+
+func TestNodeStatusWatcher_updateState(t *testing.T) {
+	watcher := &NodeStatusWatcher{
+		logger:      hclog.NewNullLogger(),
+		initialDone: make(chan bool),
+	}
+
+	watcher.updateState([]*api.NodeListStub{
+		{ID: "a", Status: api.NodeStatusReady, SchedulingEligibility: "eligible"},
+		{ID: "b", Status: api.NodeStatusDisconnected, SchedulingEligibility: "eligible"},
+		{ID: "c", Status: api.NodeStatusDown, SchedulingEligibility: nodeStatusIneligible},
+	}, nil)
+
+	total, unavailable := watcher.Stats()
+	assert.Equal(t, 3, total)
+	assert.Equal(t, 2, unavailable)
+
+	assert.True(t, watcher.IsUnavailable("b"))
+	assert.True(t, watcher.IsUnavailable("c"))
+	assert.False(t, watcher.IsUnavailable("a"))
+
+	assert.True(t, watcher.IsIneligible("c"))
+	assert.False(t, watcher.IsIneligible("b"))
+
+	// An API error must not clear the last known good state.
+	watcher.updateState(nil, assert.AnError)
+
+	total, unavailable = watcher.Stats()
+	assert.Equal(t, 3, total)
+	assert.Equal(t, 2, unavailable)
+}

--- a/pkg/nomadmeta/counter.go
+++ b/pkg/nomadmeta/counter.go
@@ -89,11 +89,11 @@ func (n *nodeCounter) list(filter, nodePool, token string) ([]string, string, er
 	var nodes []string
 
 	for _, nd := range nodeList {
-		// A partitioned client reports "disconnected" for the whole
-		// disconnect.lost_after window before it becomes "down". Counting it as
-		// capacity keeps the target inflated until expiry, then drops it in one
-		// step across every job at once.
-		if nd.Status == api.NodeStatusDown || nd.Status == api.NodeStatusDisconnected {
+		// Only "down" means the capacity is gone. A "disconnected" node is still
+		// inside its disconnect.lost_after window and its allocs can reconnect, so
+		// it has to keep counting or the autoscaler frees a slot that the
+		// returning alloc still needs, and Nomad kills it on reconnect.
+		if nd.Status == api.NodeStatusDown {
 			continue
 		}
 		if nd.NodePool == nodePool || nodePool == nodePoolAllNodes {

--- a/pkg/nomadmeta/counter.go
+++ b/pkg/nomadmeta/counter.go
@@ -89,7 +89,11 @@ func (n *nodeCounter) list(filter, nodePool, token string) ([]string, string, er
 	var nodes []string
 
 	for _, nd := range nodeList {
-		if nd.Status == "down" {
+		// A partitioned client reports "disconnected" for the whole
+		// disconnect.lost_after window before it becomes "down". Counting it as
+		// capacity keeps the target inflated until expiry, then drops it in one
+		// step across every job at once.
+		if nd.Status == api.NodeStatusDown || nd.Status == api.NodeStatusDisconnected {
 			continue
 		}
 		if nd.NodePool == nodePool || nodePool == nodePoolAllNodes {

--- a/pkg/nomadmeta/counter_test.go
+++ b/pkg/nomadmeta/counter_test.go
@@ -1,0 +1,80 @@
+package nomadmeta
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/go-hclog"
+	"github.com/hashicorp/nomad/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type counterTestNode struct {
+	name   string
+	status string
+}
+
+func nodeListServer(t *testing.T, nodes []counterTestNode) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		stubs := make([]string, 0, len(nodes))
+
+		for _, nd := range nodes {
+			stubs = append(stubs, fmt.Sprintf(
+				`{"ID":%q,"Name":%q,"Status":%q,"NodePool":"default","SchedulingEligibility":"eligible"}`,
+				nd.name, nd.name, nd.status))
+		}
+
+		_, _ = w.Write([]byte("[" + strings.Join(stubs, ",") + "]"))
+	}))
+}
+
+func TestNodeCounter_GetNodeNames_ExcludesUnavailable(t *testing.T) {
+	server := nodeListServer(t, []counterTestNode{
+		{name: "ready-1", status: api.NodeStatusReady},
+		{name: "ready-2", status: api.NodeStatusReady},
+		{name: "gone", status: api.NodeStatusDown},
+		{name: "partitioned", status: api.NodeStatusDisconnected},
+		{name: "starting", status: api.NodeStatusInit},
+	})
+	defer server.Close()
+
+	cfg := api.DefaultConfig()
+	cfg.Address = server.URL
+	client, err := api.NewClient(cfg)
+	require.NoError(t, err)
+
+	counter := NewCounter(client, hclog.NewNullLogger(), nil, DefaultPageSize)
+
+	names, err := counter.GetNodeNames("", "default")
+	require.NoError(t, err)
+
+	// A partitioned client reports "disconnected" for the whole lost_after
+	// window, so counting it would keep the target inflated until expiry.
+	assert.ElementsMatch(t, []string{"ready-1", "ready-2", "starting"}, names)
+}
+
+func TestNodeCounter_GetNodeNames_AllNodePools(t *testing.T) {
+	server := nodeListServer(t, []counterTestNode{
+		{name: "ready-1", status: api.NodeStatusReady},
+		{name: "partitioned", status: api.NodeStatusDisconnected},
+	})
+	defer server.Close()
+
+	cfg := api.DefaultConfig()
+	cfg.Address = server.URL
+	client, err := api.NewClient(cfg)
+	require.NoError(t, err)
+
+	counter := NewCounter(client, hclog.NewNullLogger(), nil, DefaultPageSize)
+
+	names, err := counter.GetNodeNames("", nodePoolAllNodes)
+	require.NoError(t, err)
+
+	assert.ElementsMatch(t, []string{"ready-1"}, names)
+}

--- a/pkg/nomadmeta/counter_test.go
+++ b/pkg/nomadmeta/counter_test.go
@@ -34,7 +34,7 @@ func nodeListServer(t *testing.T, nodes []counterTestNode) *httptest.Server {
 	}))
 }
 
-func TestNodeCounter_GetNodeNames_ExcludesUnavailable(t *testing.T) {
+func TestNodeCounter_GetNodeNames_ExcludesDownKeepsDisconnected(t *testing.T) {
 	server := nodeListServer(t, []counterTestNode{
 		{name: "ready-1", status: api.NodeStatusReady},
 		{name: "ready-2", status: api.NodeStatusReady},
@@ -54,15 +54,16 @@ func TestNodeCounter_GetNodeNames_ExcludesUnavailable(t *testing.T) {
 	names, err := counter.GetNodeNames("", "default")
 	require.NoError(t, err)
 
-	// A partitioned client reports "disconnected" for the whole lost_after
-	// window, so counting it would keep the target inflated until expiry.
-	assert.ElementsMatch(t, []string{"ready-1", "ready-2", "starting"}, names)
+	// Dropping the disconnected node here would lower the target while its allocs
+	// are still holding their slots, so the autoscaler would scale the group down
+	// and Nomad would kill those allocs when the node came back.
+	assert.ElementsMatch(t, []string{"ready-1", "ready-2", "partitioned", "starting"}, names)
 }
 
 func TestNodeCounter_GetNodeNames_AllNodePools(t *testing.T) {
 	server := nodeListServer(t, []counterTestNode{
 		{name: "ready-1", status: api.NodeStatusReady},
-		{name: "partitioned", status: api.NodeStatusDisconnected},
+		{name: "gone", status: api.NodeStatusDown},
 	})
 	defer server.Close()
 

--- a/plugins/kentik/target/nomad/plugin/plugin.go
+++ b/plugins/kentik/target/nomad/plugin/plugin.go
@@ -5,6 +5,7 @@ package nomad
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,14 @@ const (
 	configKeyNamespace       = "Namespace"
 	configCheckUnknownAllocs = "CheckUnknownAllocs"
 	configNodePool           = "NodePool"
+
+	// configMaxUnavailableFraction bounds how much of the cluster may be
+	// unavailable before the plugin stops reporting status.
+	configMaxUnavailableFraction = "MaxUnavailableFraction"
+
+	// defaultMaxUnavailableFraction is deliberately permissive enough to allow
+	// a single datacenter loss to be handled, but not a majority outage.
+	defaultMaxUnavailableFraction = 0.5
 
 	// garbageCollectionNanoSecondThreshold is the nanosecond threshold used
 	// when performing garbage collection of job status handlers.
@@ -209,6 +218,16 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 		checkUnknownAllocs = true
 	}
 
+	maxUnavailableFraction := defaultMaxUnavailableFraction
+
+	if raw, ok := config[configMaxUnavailableFraction]; ok {
+		parsed, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			return nil, fmt.Errorf("config key %q must be a float: %v", configMaxUnavailableFraction, err)
+		}
+		maxUnavailableFraction = parsed
+	}
+
 	nsID := namespacedJobID{namespace: namespace, job: jobID}
 
 	// Create a read/write lock on the handlers so we can safely interact.
@@ -217,7 +236,7 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 
 	// Create a handler for the job if one does not currently exist.
 	if _, ok := t.statusHandlers[nsID]; !ok {
-		jsh, err := newJobScaleStatusHandler(t.client, namespace, jobID, checkUnknownAllocs, t.logger, t.nodeWatcher)
+		jsh, err := newJobScaleStatusHandler(t.client, namespace, jobID, checkUnknownAllocs, maxUnavailableFraction, t.logger, t.nodeWatcher)
 		if err != nil {
 			return nil, err
 		}

--- a/plugins/kentik/target/nomad/plugin/plugin.go
+++ b/plugins/kentik/target/nomad/plugin/plugin.go
@@ -225,6 +225,10 @@ func (t *TargetPlugin) Status(config map[string]string) (*sdk.TargetStatus, erro
 		if err != nil {
 			return nil, fmt.Errorf("config key %q must be a float: %v", configMaxUnavailableFraction, err)
 		}
+		// Reject NaN/Inf and out-of-range values; 0 disables the guard.
+		if parsed != parsed || parsed < 0 || parsed > 1 {
+			return nil, fmt.Errorf("config key %q must be between 0 and 1 (inclusive), got %q", configMaxUnavailableFraction, raw)
+		}
 		maxUnavailableFraction = parsed
 	}
 

--- a/plugins/kentik/target/nomad/plugin/plugin_test.go
+++ b/plugins/kentik/target/nomad/plugin/plugin_test.go
@@ -101,6 +101,16 @@ func TestTargetPlugin_Status_UnknownAllocs(t *testing.T) {
 		"nomad_address": nomadMock.URL,
 	})
 
+	// Unknown allocs still occupy the group count, so they are reported rather
+	// than aborting the evaluation.
+	expected := &sdk.TargetStatus{
+		Ready: true,
+		Count: 2,
+		Meta: map[string]string{
+			"nomad_autoscaler.target.nomad.example.stopped": "false",
+		},
+	}
+
 	got, err := plugin.Status(map[string]string{
 		"Job":                "example",
 		"Group":              "cache",
@@ -108,8 +118,8 @@ func TestTargetPlugin_Status_UnknownAllocs(t *testing.T) {
 		"CheckUnknownAllocs": "true",
 	})
 
-	assert.Nil(t, got)
-	assert.Error(t, err)
+	require.NoError(t, err)
+	assert.Equal(t, expected, got)
 
 	// Call Status multiple times concurrently to test for data races.
 	var wg sync.WaitGroup
@@ -122,10 +132,89 @@ func TestTargetPlugin_Status_UnknownAllocs(t *testing.T) {
 				"Group":     "cache",
 				"Namespace": "default",
 			})
-			assert.Error(t, err)
+			assert.NoError(t, err)
 		}()
 	}
 	wg.Wait()
+}
+
+func TestTargetPlugin_Status_DisconnectedNodeCountsTowardsGroup(t *testing.T) {
+	// One of three nodes is partitioned, which is below the guard threshold, so
+	// the handler should still report and include the unknown alloc.
+	nodes := []testNode{
+		{id: allocNodeID, eligibility: "eligible", status: "disconnected"},
+		{id: "11111111-0000-0000-0000-000000000001", eligibility: "eligible", status: "ready"},
+		{id: "11111111-0000-0000-0000-000000000002", eligibility: "eligible", status: "ready"},
+	}
+
+	nomadMock := httptest.NewServer(http.HandlerFunc(statusHandlerForNodes(true, nodes)))
+	defer nomadMock.Close()
+
+	plugin := PluginConfig.Factory(hclog.NewNullLogger()).(*TargetPlugin)
+	plugin.SetConfig(map[string]string{
+		"nomad_address": nomadMock.URL,
+	})
+
+	got, err := plugin.Status(map[string]string{
+		"Job":                "example",
+		"Group":              "cache",
+		"Namespace":          "default",
+		"CheckUnknownAllocs": "true",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(2), got.Count)
+}
+
+func TestTargetPlugin_Status_RefusesWhenMajorityUnavailable(t *testing.T) {
+	// Two of three nodes unavailable exceeds the default 0.5 threshold, which
+	// most likely means the control plane lost visibility rather than that the
+	// capacity is genuinely gone.
+	nodes := []testNode{
+		{id: allocNodeID, eligibility: "eligible", status: "disconnected"},
+		{id: "11111111-0000-0000-0000-000000000001", eligibility: "eligible", status: "down"},
+		{id: "11111111-0000-0000-0000-000000000002", eligibility: "eligible", status: "ready"},
+	}
+
+	nomadMock := httptest.NewServer(http.HandlerFunc(statusHandlerForNodes(true, nodes)))
+	defer nomadMock.Close()
+
+	plugin := PluginConfig.Factory(hclog.NewNullLogger()).(*TargetPlugin)
+	plugin.SetConfig(map[string]string{
+		"nomad_address": nomadMock.URL,
+	})
+
+	got, err := plugin.Status(map[string]string{
+		"Job":                "example",
+		"Group":              "cache",
+		"Namespace":          "default",
+		"CheckUnknownAllocs": "true",
+	})
+
+	assert.Nil(t, got)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nodes unavailable")
+}
+
+func TestTargetPlugin_Status_InvalidMaxUnavailableFraction(t *testing.T) {
+	nomadMock := httptest.NewServer(http.HandlerFunc(statusHandler(false, false)))
+	defer nomadMock.Close()
+
+	plugin := PluginConfig.Factory(hclog.NewNullLogger()).(*TargetPlugin)
+	plugin.SetConfig(map[string]string{
+		"nomad_address": nomadMock.URL,
+	})
+
+	_, err := plugin.Status(map[string]string{
+		"Job":                    "example",
+		"Group":                  "cache",
+		"Namespace":              "default",
+		"MaxUnavailableFraction": "not-a-float",
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "must be a float")
 }
 
 func TestTargetPlugin_Status_UnknownAllocsWithIneligibleNode(t *testing.T) {
@@ -203,7 +292,27 @@ func TestTargetPlugin_statusTimeout(t *testing.T) {
 	assert.Nil(t, status)
 }
 
+// allocNodeID is the node the allocation fixture is placed on.
+const allocNodeID = "cb1f6030-a220-4f92-57dc-7baaabdc3823"
+
+type testNode struct {
+	id          string
+	eligibility string
+	status      string
+}
+
 func statusHandler(unknownAllocs, ineligibleNodes bool) func(w http.ResponseWriter, r *http.Request) {
+	eligibility := "eligible"
+	if ineligibleNodes {
+		eligibility = "ineligible"
+	}
+
+	return statusHandlerForNodes(unknownAllocs, []testNode{
+		{id: allocNodeID, eligibility: eligibility, status: "ready"},
+	})
+}
+
+func statusHandlerForNodes(unknownAllocs bool, nodes []testNode) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if strings.HasSuffix(r.URL.Path, "/scale") {
 			scaleStatusHandler(w, r)
@@ -212,7 +321,7 @@ func statusHandler(unknownAllocs, ineligibleNodes bool) func(w http.ResponseWrit
 			allocsHandler(unknownAllocs)(w, r)
 			return
 		} else if strings.HasSuffix(r.URL.Path, "/nodes") {
-			nodesHandler(ineligibleNodes)(w, r)
+			nodesHandler(nodes)(w, r)
 			return
 		}
 	}
@@ -280,15 +389,12 @@ func allocsHandler(unknownAllocs bool) func(w http.ResponseWriter, r *http.Reque
 	}
 }
 
-func nodesHandler(ineligibleNodes bool) func(w http.ResponseWriter, r *http.Request) {
+func nodesHandler(nodes []testNode) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		status := "eligible"
-		if ineligibleNodes {
-			status = "ineligible"
-		}
+		stubs := make([]string, 0, len(nodes))
 
-		respBody := fmt.Sprintf(`
-[
+		for _, nd := range nodes {
+			stubs = append(stubs, fmt.Sprintf(`
   {
     "Address": "10.138.0.5",
     "Attributes": {
@@ -297,31 +403,19 @@ func nodesHandler(ineligibleNodes bool) func(w http.ResponseWriter, r *http.Requ
     "CreateIndex": 6,
     "Datacenter": "dc1",
     "Drain": false,
-    "Drivers": {
-      "docker": {
-        "Attributes": {
-          "driver.docker.bridge_ip": "172.17.0.1",
-          "driver.docker.version": "18.03.0-ce",
-          "driver.docker.volumes.enabled": "1"
-        },
-        "Detected": true,
-        "HealthDescription": "Driver is available and responsive",
-        "Healthy": true,
-        "UpdateTime": "2018-04-11T23:34:48.713720323Z"
-      }
-    },
-    "ID": "cb1f6030-a220-4f92-57dc-7baaabdc3823",
+    "ID": %q,
     "LastDrain": null,
     "ModifyIndex": 2526,
-    "Name": "nomad-4",
+    "Name": %q,
     "NodeClass": "",
-    "SchedulingEligibility": "%s",
-    "Status": "ready",
+    "SchedulingEligibility": %q,
+    "Status": %q,
     "StatusDescription": "",
     "Version": "0.8.0-rc1"
-  }
-]`, status)
-		_, _ = w.Write([]byte(respBody))
+  }`, nd.id, nd.id, nd.eligibility, nd.status))
+		}
+
+		_, _ = w.Write([]byte("[" + strings.Join(stubs, ",") + "]"))
 	}
 }
 

--- a/plugins/kentik/target/nomad/plugin/plugin_test.go
+++ b/plugins/kentik/target/nomad/plugin/plugin_test.go
@@ -101,11 +101,11 @@ func TestTargetPlugin_Status_UnknownAllocs(t *testing.T) {
 		"nomad_address": nomadMock.URL,
 	})
 
-	// Unknown allocs still occupy the group count, so they are reported rather
-	// than aborting the evaluation.
+	// Unknown allocs already occupy a slot in the group's configured count, so
+	// the reported count is the configured count.
 	expected := &sdk.TargetStatus{
 		Ready: true,
-		Count: 2,
+		Count: 1,
 		Meta: map[string]string{
 			"nomad_autoscaler.target.nomad.example.stopped": "false",
 		},
@@ -140,7 +140,7 @@ func TestTargetPlugin_Status_UnknownAllocs(t *testing.T) {
 
 func TestTargetPlugin_Status_DisconnectedNodeCountsTowardsGroup(t *testing.T) {
 	// One of three nodes is partitioned, which is below the guard threshold, so
-	// the handler should still report and include the unknown alloc.
+	// the handler should still report the group's configured count.
 	nodes := []testNode{
 		{id: allocNodeID, eligibility: "eligible", status: "disconnected"},
 		{id: "11111111-0000-0000-0000-000000000001", eligibility: "eligible", status: "ready"},
@@ -148,6 +148,44 @@ func TestTargetPlugin_Status_DisconnectedNodeCountsTowardsGroup(t *testing.T) {
 	}
 
 	nomadMock := httptest.NewServer(http.HandlerFunc(statusHandlerForNodes(true, nodes)))
+	defer nomadMock.Close()
+
+	plugin := PluginConfig.Factory(hclog.NewNullLogger()).(*TargetPlugin)
+	plugin.SetConfig(map[string]string{
+		"nomad_address": nomadMock.URL,
+	})
+
+	got, err := plugin.Status(map[string]string{
+		"Job":                "example",
+		"Group":              "cache",
+		"Namespace":          "default",
+		"CheckUnknownAllocs": "true",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, int64(1), got.Count)
+}
+
+func TestTargetPlugin_Status_DegradedJobReportsConfiguredCount(t *testing.T) {
+	// A node was lost and the replacement cannot be placed, so the group is left
+	// with desired=2 running=1. Reporting the running count here would make the
+	// strategy see current==target and never scale the group back down, leaving
+	// the job degraded indefinitely.
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		if strings.HasSuffix(r.URL.Path, "/scale") {
+			scaleStatusHandlerFor(2, 1)(w, r)
+			return
+		} else if strings.HasSuffix(r.URL.Path, "/allocations") {
+			allocsHandler(false)(w, r)
+			return
+		} else if strings.HasSuffix(r.URL.Path, "/nodes") {
+			nodesHandler([]testNode{{id: allocNodeID, eligibility: "eligible", status: "ready"}})(w, r)
+			return
+		}
+	}
+
+	nomadMock := httptest.NewServer(http.HandlerFunc(handler))
 	defer nomadMock.Close()
 
 	plugin := PluginConfig.Factory(hclog.NewNullLogger()).(*TargetPlugin)
@@ -228,7 +266,7 @@ func TestTargetPlugin_Status_UnknownAllocsWithIneligibleNode(t *testing.T) {
 
 	expected := &sdk.TargetStatus{
 		Ready: true,
-		Count: 2, // should count the ineligible node
+		Count: 1,
 		Meta: map[string]string{
 			"nomad_autoscaler.target.nomad.example.stopped": "false",
 		},
@@ -328,8 +366,12 @@ func statusHandlerForNodes(unknownAllocs bool, nodes []testNode) func(w http.Res
 }
 
 func scaleStatusHandler(w http.ResponseWriter, r *http.Request) {
+	scaleStatusHandlerFor(1, 1)(w, r)
+}
 
-	respBody := `
+func scaleStatusHandlerFor(desired, running int) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		respBody := fmt.Sprintf(`
 {
   "JobCreateIndex": 10,
   "JobID": "example",
@@ -338,16 +380,17 @@ func scaleStatusHandler(w http.ResponseWriter, r *http.Request) {
   "JobStopped": false,
   "TaskGroups": {
     "cache": {
-      "Desired": 1,
+      "Desired": %d,
       "Events": null,
-      "Healthy": 1,
-      "Placed": 1,
-      "Running": 1,
+      "Healthy": %d,
+      "Placed": %d,
+      "Running": %d,
       "Unhealthy": 0
     }
   }
-}`
-	w.Write([]byte(respBody))
+}`, desired, running, running, running)
+		w.Write([]byte(respBody))
+	}
 }
 
 func allocsHandler(unknownAllocs bool) func(w http.ResponseWriter, r *http.Request) {

--- a/plugins/kentik/target/nomad/plugin/state.go
+++ b/plugins/kentik/target/nomad/plugin/state.go
@@ -49,6 +49,10 @@ type jobScaleStatusHandler struct {
 	jobID              string
 	checkUnknownAllocs bool
 
+	// maxUnavailableFraction is the share of cluster nodes allowed to be
+	// unavailable before this handler stops reporting status. Zero disables it.
+	maxUnavailableFraction float64
+
 	// lock is used to synchronize access to the status variables below.
 	lock sync.RWMutex
 
@@ -74,13 +78,14 @@ type jobScaleStatusHandler struct {
 	lastUpdated int64
 }
 
-func newJobScaleStatusHandler(client *api.Client, ns, jobID string, checkUnknownAllocs bool, logger hclog.Logger, nodes node.Status) (*jobScaleStatusHandler, error) {
+func newJobScaleStatusHandler(client *api.Client, ns, jobID string, checkUnknownAllocs bool, maxUnavailableFraction float64, logger hclog.Logger, nodes node.Status) (*jobScaleStatusHandler, error) {
 	jsh := &jobScaleStatusHandler{
 		client:                  client,
 		initialDone:             make(chan bool),
 		jobID:                   jobID,
 		namespace:               ns,
 		checkUnknownAllocs:      checkUnknownAllocs,
+		maxUnavailableFraction:  maxUnavailableFraction,
 		logger:                  logger.With(configKeyJobID, jobID),
 		nodes:                   nodes,
 		ineligibleUnknownAllocs: IneligibleUnknownAllocs{},
@@ -117,9 +122,18 @@ func (jsh *jobScaleStatusHandler) status(group string) (*sdk.TargetStatus, error
 			jsh.logger.Info("returning alloc status error")
 			return nil, jsh.allocStatusError
 		}
-		if count, exists := jsh.unknownAllocs[group]; exists {
-			jsh.logger.Info("returning status error because there are unknown allocs")
-			return nil, fmt.Errorf("group %s contains %d unknown allocs", group, count)
+
+		// Losing sight of a large share of the fleet at once is far more likely
+		// to be a control plane problem than real capacity loss, and acting on
+		// that reading would shrink every job in the cluster simultaneously.
+		if total, unavailable := jsh.nodes.Stats(); jsh.maxUnavailableFraction > 0 &&
+			total > 0 && float64(unavailable)/float64(total) > jsh.maxUnavailableFraction {
+			jsh.logger.Warn("refusing to report status, too many nodes unavailable",
+				"unavailable", unavailable, "total", total,
+				"threshold", jsh.maxUnavailableFraction)
+			return nil, fmt.Errorf(
+				"refusing to report status: %d of %d nodes unavailable, above threshold %.2f",
+				unavailable, total, jsh.maxUnavailableFraction)
 		}
 	}
 
@@ -149,6 +163,17 @@ func (jsh *jobScaleStatusHandler) status(group string) (*sdk.TargetStatus, error
 	}
 
 	count := int64(status.Running)
+
+	// Nomad's scale status counts only ClientStatus==running, but unknown allocs
+	// are non-terminal and still occupy the group's count. Omitting them would
+	// make current==target, so the autoscaler would never lower the count and
+	// Nomad would keep retrying placements the group's constraints cannot
+	// satisfy.
+	if unknown, exists := jsh.unknownAllocs[group]; exists {
+		jsh.logger.Info("including unknown allocs in reported count",
+			"group", group, "unknown", unknown, "running", count)
+		count += int64(unknown)
+	}
 
 	if ineligible, exists := jsh.ineligibleUnknownAllocs[group]; exists {
 		jsh.logger.Info(

--- a/plugins/kentik/target/nomad/plugin/state.go
+++ b/plugins/kentik/target/nomad/plugin/state.go
@@ -162,30 +162,26 @@ func (jsh *jobScaleStatusHandler) status(group string) (*sdk.TargetStatus, error
 		return nil, fmt.Errorf("task group %q not found", group)
 	}
 
-	count := int64(status.Running)
+	// Report the group's configured count rather than how many allocs are
+	// running. The strategy does nothing when the reported count already equals
+	// the target, so reporting `Running` during an outage makes current==target
+	// and the count is never corrected back down, leaving the job degraded.
+	// Unknown allocs already occupy a slot in Desired, so they need no adjustment.
+	count := int64(status.Desired)
 
-	// Nomad's scale status counts only ClientStatus==running, but unknown allocs
-	// are non-terminal and still occupy the group's count. Omitting them would
-	// make current==target, so the autoscaler would never lower the count and
-	// Nomad would keep retrying placements the group's constraints cannot
-	// satisfy.
 	if unknown, exists := jsh.unknownAllocs[group]; exists {
-		jsh.logger.Info("including unknown allocs in reported count",
-			"group", group, "unknown", unknown, "running", count)
-		count += int64(unknown)
+		jsh.logger.Info("group has unknown allocs on connected nodes",
+			"group", group, "unknown", unknown, "desired", count)
 	}
 
 	if ineligible, exists := jsh.ineligibleUnknownAllocs[group]; exists {
-		jsh.logger.Info(
-			"adjusting target count since group has unknown allocs running on ineligible nodes. APM plugin should force a downscale",
-			"group", group,
-			"ineligible", ineligible,
-			"count", count,
-		)
-		count += int64(ineligible)
+		jsh.logger.Info("group has unknown allocs on ineligible nodes",
+			"group", group, "ineligible", ineligible, "desired", count)
 	}
+
 	if status.Desired > status.Running {
-		jsh.logger.Warn("desired count is bigger than running count, job is probably degraded", group, group, "desired", status.Desired, "running", status.Running)
+		jsh.logger.Warn("desired count is bigger than running count, job is probably degraded",
+			"group", group, "desired", status.Desired, "running", status.Running)
 	}
 
 	// Hydrate the response object with the information we have collected that

--- a/plugins/kentik/target/nomad/plugin/state_test.go
+++ b/plugins/kentik/target/nomad/plugin/state_test.go
@@ -59,7 +59,7 @@ func Test_newJobStateHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create the new handler and perform assertions.
-	jsh, err := newJobScaleStatusHandler(c, "default", "test", false, hclog.NewNullLogger(), nodeStatus)
+	jsh, err := newJobScaleStatusHandler(c, "default", "test", false, defaultMaxUnavailableFraction, hclog.NewNullLogger(), nodeStatus)
 	require.NoError(t, err)
 
 	assert.NotNil(t, jsh.client)

--- a/plugins/kentik/target/nomad/plugin/state_test.go
+++ b/plugins/kentik/target/nomad/plugin/state_test.go
@@ -107,7 +107,7 @@ func Test_jobStateHandler_status(t *testing.T) {
 				scaleStatus: &api.JobScaleStatusResponse{
 					JobStopped: false,
 					TaskGroups: map[string]api.TaskGroupScaleStatus{
-						"this-does-exist": {Running: 7},
+						"this-does-exist": {Desired: 7, Running: 7},
 					},
 				},
 			},
@@ -126,9 +126,30 @@ func Test_jobStateHandler_status(t *testing.T) {
 			inputJSH: &jobScaleStatusHandler{
 				jobID: "cant-think-of-a-funny-name",
 				scaleStatus: &api.JobScaleStatusResponse{
+					JobStopped: false,
+					TaskGroups: map[string]api.TaskGroupScaleStatus{
+						"this-does-exist": {Desired: 2, Running: 1},
+					},
+				},
+			},
+			inputGroup: "this-does-exist",
+			expectedReturn: &sdk.TargetStatus{
+				Ready: true,
+				Count: 2,
+				Meta: map[string]string{
+					"nomad_autoscaler.target.nomad.cant-think-of-a-funny-name.stopped": "false",
+				},
+			},
+			expectedError: nil,
+			name:          "degraded group reports the configured count so it can be corrected",
+		},
+		{
+			inputJSH: &jobScaleStatusHandler{
+				jobID: "cant-think-of-a-funny-name",
+				scaleStatus: &api.JobScaleStatusResponse{
 					JobStopped: true,
 					TaskGroups: map[string]api.TaskGroupScaleStatus{
-						"this-does-exist": {Running: 7},
+						"this-does-exist": {Desired: 7, Running: 7},
 					},
 				},
 			},

--- a/plugins/target/client.go
+++ b/plugins/target/client.go
@@ -32,7 +32,7 @@ func (p *pluginClient) Scale(action sdk.ScalingAction, config map[string]string)
 		return err
 	}
 	_, err = p.client.Scale(p.doneCTX, &proto.ScaleRequest{Action: req, Config: config})
-	return err
+	return scaleErrorFromStatus(err)
 }
 
 // Status is the gRPC client implementation of the Target.Status interface

--- a/plugins/target/scale_error_test.go
+++ b/plugins/target/scale_error_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package target
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func Test_scaleErrorRoundTrip(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    error
+		assertFn func(t *testing.T, got error)
+	}{
+		{
+			name:  "no error",
+			input: nil,
+			assertFn: func(t *testing.T, got error) {
+				assert.NoError(t, got)
+			},
+		},
+		{
+			name:  "no-op error survives the boundary",
+			input: sdk.NewTargetScalingNoOpError("skipping scaling group %s/%s due to active deployment", "envoy-frontend", "envoy-frontend"),
+			assertFn: func(t *testing.T, got error) {
+				var noOpErr *sdk.TargetScalingNoOpError
+				require.ErrorAs(t, got, &noOpErr)
+				assert.Equal(t, "skipping scaling group envoy-frontend/envoy-frontend due to active deployment", got.Error())
+			},
+		},
+		{
+			name:  "genuine failure is not mistaken for a no-op",
+			input: errors.New("failed to scale group a/b: connection refused"),
+			assertFn: func(t *testing.T, got error) {
+				var noOpErr *sdk.TargetScalingNoOpError
+				require.Error(t, got)
+				assert.NotErrorIs(t, got, noOpErr)
+				assert.False(t, errors.As(got, &noOpErr))
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// The gRPC layer only preserves the status code and message, so
+			// round-tripping through it is what the plugin boundary really does.
+			encoded := scaleErrorToStatus(tc.input)
+
+			var overTheWire error
+			if encoded != nil {
+				s, _ := status.FromError(encoded)
+				overTheWire = s.Err()
+			}
+
+			tc.assertFn(t, scaleErrorFromStatus(overTheWire))
+		})
+	}
+}
+
+func Test_scaleErrorFromStatus_IgnoresOtherCodes(t *testing.T) {
+	err := scaleErrorFromStatus(status.Error(codes.Unavailable, "plugin exited"))
+
+	var noOpErr *sdk.TargetScalingNoOpError
+	assert.False(t, errors.As(err, &noOpErr))
+	assert.Equal(t, codes.Unavailable, status.Code(err))
+}

--- a/plugins/target/scale_error_test.go
+++ b/plugins/target/scale_error_test.go
@@ -42,7 +42,6 @@ func Test_scaleErrorRoundTrip(t *testing.T) {
 			assertFn: func(t *testing.T, got error) {
 				var noOpErr *sdk.TargetScalingNoOpError
 				require.Error(t, got)
-				assert.NotErrorIs(t, got, noOpErr)
 				assert.False(t, errors.As(got, &noOpErr))
 			},
 		},

--- a/plugins/target/server.go
+++ b/plugins/target/server.go
@@ -24,7 +24,12 @@ func (p *pluginServer) Scale(_ context.Context, req *proto.ScaleRequest) (*proto
 	if err != nil {
 		return nil, err
 	}
-	return &proto.ScaleResponse{}, p.impl.Scale(action, req.GetConfig())
+
+	if err := p.impl.Scale(action, req.GetConfig()); err != nil {
+		return nil, scaleErrorToStatus(err)
+	}
+
+	return &proto.ScaleResponse{}, nil
 }
 
 // Status is the gRPC server implementation of the Target.Status interface

--- a/plugins/target/target.go
+++ b/plugins/target/target.go
@@ -4,9 +4,42 @@
 package target
 
 import (
+	"errors"
+
 	"github.com/hashicorp/nomad-autoscaler/plugins/base"
 	"github.com/hashicorp/nomad-autoscaler/sdk"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// scalingNoOpCode carries sdk.TargetScalingNoOpError across the plugin gRPC
+// boundary, which flattens concrete error types to a status code and message.
+// No other error in the Scale path maps to this code.
+const scalingNoOpCode = codes.FailedPrecondition
+
+// scaleErrorToStatus encodes an error returned by a Target implementation so
+// the client can reconstruct its type.
+func scaleErrorToStatus(err error) error {
+	var noOpErr *sdk.TargetScalingNoOpError
+	if errors.As(err, &noOpErr) {
+		return status.Error(scalingNoOpCode, err.Error())
+	}
+
+	return err
+}
+
+// scaleErrorFromStatus reverses scaleErrorToStatus.
+func scaleErrorFromStatus(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	if status.Code(err) == scalingNoOpCode {
+		return &sdk.TargetScalingNoOpError{Err: errors.New(status.Convert(err).Message())}
+	}
+
+	return err
+}
 
 // Target is the interface that all Target plugins are required to implement.
 // The plugins are responsible for providing status details of the remote

--- a/policyeval/base_worker.go
+++ b/policyeval/base_worker.go
@@ -320,7 +320,8 @@ func (w *BaseWorker) scaleTarget(
 
 	err := runTargetScale(targetImpl, policy, action)
 	if err != nil {
-		if _, ok := err.(*sdk.TargetScalingNoOpError); ok {
+		var noOpErr *sdk.TargetScalingNoOpError
+		if errors.As(err, &noOpErr) {
 			logger.Info("scaling action skipped", "reason", err)
 			return nil
 		}

--- a/project.yml
+++ b/project.yml
@@ -11,7 +11,7 @@ lint:
 nomad:
   - service_group: nomad-autoscaler
     pack: service
-    branch: bv-disconnect
+    branch: main
 docker:
   build:
     base: kt-build-generic-bullseye:master

--- a/project.yml
+++ b/project.yml
@@ -11,7 +11,7 @@ lint:
 nomad:
   - service_group: nomad-autoscaler
     pack: service
-    branch: main
+    branch: bv-disconnect
 docker:
   build:
     base: kt-build-generic-bullseye:master


### PR DESCRIPTION
## Problem

The Kentik target plugin stopped the autoscaler from doing anything useful whenever a client disconnected, and separately, the "skip this scaling action" signal was being lost between the plugin process and the agent.

**1. A single `unknown` allocation froze scaling for the whole job.**

`jobScaleStatusHandler.status()` returned a hard error if any allocation in the group was `unknown` on an eligible node:

```go
if count, exists := jsh.unknownAllocs[group]; exists {
    return nil, fmt.Errorf("group %s contains %d unknown allocs", group, count)
}
```

`CheckUnknownAllocs = "true"` is rendered for every scaled job by the `service` pack, so one disconnected client aborted policy evaluation for that job for the entire `disconnect.lost_after` window — three hours. Operators could not add capacity through the normal path during exactly the incident where they most needed to.

**2. Reporting `Running` meant the count was never corrected.**

The plugin reported `status.Running` as the current count. During an outage the APM target drops too, so `current == target`, the strategy decides there is nothing to do, and Nomad's group `count` is never brought back down. The job sits degraded with a `count` it cannot satisfy, and the surplus allocations keep producing placement attempts that cannot succeed.

The existing `ineligibleUnknownAllocs` adjustment was a workaround for this: it added allocations on ineligible nodes back into the count so a drain would not look like a capacity change. It only patched the drain case, not disconnects.

**3. `TargetScalingNoOpError` did not survive the plugin boundary.**

The Nomad target returns `sdk.TargetScalingNoOpError` for expected, non-fatal conditions — most importantly `job scaling blocked due to active deployment`, which happens routinely because `Job.Scale` goes through `Job.Register` and is refused while a deployment is active. gRPC flattens concrete error types to a status code and message, so by the time `policyeval` saw it, it was an ordinary error and got logged and counted as a scaling failure. The check there was also a type assertion, so it could not see through wrapping:

```go
if _, ok := err.(*sdk.TargetScalingNoOpError); ok {
```

## Solution

**Report `Desired`, not `Running`** — `plugins/kentik/target/nomad/plugin/state.go`

`status.Desired` is Nomad's configured group count, which is the quantity the autoscaler actually needs to converge. `unknown` allocations already occupy a slot in `Desired`, so no adjustment is needed and the `ineligibleUnknownAllocs` fudge factor is dropped (both it and the disconnect case now fall out of the same rule). The ineligible/unknown counts are still logged, just no longer added.

This keeps the APM and the target in agreement during a disconnect:

| | APM target | current (`Desired`) | action |
|---|---|---|---|
| nodes disconnected | 10 | 10 | none |
| node reconnects | 10 | 10 | none — the allocation survives |
| `lost_after` expires, node `down` | 6 | 10 | one scale to 6 |

**Replace the hard error with a partition guard** — `state.go`, `plugin.go`

Unknown allocations no longer abort the evaluation. Instead, if more than `MaxUnavailableFraction` of the fleet is unavailable (new config key, default `0.5`), the handler declines to report. Losing sight of most of the cluster at once is far more likely to be a control plane problem than genuine capacity loss, and acting on that reading would shrink every job simultaneously.

**Track node status, not just scheduling eligibility** — `pkg/node/node.go`

`node.Status` gains `IsUnavailable` and `Stats`. The watcher now tracks `down`/`disconnected` nodes and the total node count alongside `SchedulingEligibility`, which is what the guard above needs. A disconnected node stays *eligible*, so eligibility alone could not see it.

**Preserve `TargetScalingNoOpError` across gRPC** — `plugins/target/{target,server,client}.go`

The server encodes it as `codes.FailedPrecondition`; the client reconstructs the concrete type. No other error in the `Scale` path maps to that code. `policyeval/base_worker.go` switches to `errors.As` so wrapped no-op errors are recognised too. Result: "blocked due to active deployment" is logged as a skip rather than a failure.

**No behaviour change** — `pkg/nomadmeta/counter.go`

Switched the literal `"down"` to `api.NodeStatusDown` and added a comment recording *why* `disconnected` nodes must keep counting toward the target: they are still inside their `lost_after` window and their allocations can reconnect. Dropping them would free a slot the returning allocation still needs, and Nomad would then kill it on reconnect. This is load-bearing and easy to "optimise" away by accident.